### PR TITLE
Adds params definition to ActionForm

### DIFF
--- a/lib/action_form/schema_dsl.rb
+++ b/lib/action_form/schema_dsl.rb
@@ -13,7 +13,16 @@ module ActionForm
         EasyParams::Base
       end
 
-      def params_definition(*) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def params_definition(*)
+        @params_definition ||= create_params_definition
+      end
+
+      def params(&block)
+        @params_definition = create_params_definition(&block)
+        @params_definition.class_eval(&block) if block
+      end
+
+      def create_params_definition # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         schema = Class.new(params_class)
         elements.each do |name, element_definition|
           if element_definition < ActionForm::SubformsCollection
@@ -40,7 +49,11 @@ module ActionForm
     end
 
     module InstanceMethods # rubocop:disable Style/Documentation
-      def params_definition(*) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def params_definition(*)
+        @params_definition ||= create_params_definition
+      end
+
+      def create_params_definition # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         schema = Class.new(self.class.params_class)
         elements_instances.select(&:render?).each do |element|
           case element

--- a/spec/form_params_spec.rb
+++ b/spec/form_params_spec.rb
@@ -1,0 +1,56 @@
+
+class RegistrationForm < ActionForm::Base
+  element :email do
+    input(type: :email)
+    output(type: :string, presence: true)
+  end
+  element :password do
+    input(type: :password)
+    output(type: :string)
+  end
+  element :password_confirmation do
+    input(type: :password)
+    output(type: :string)
+  end
+
+  subform :profile, default: {} do
+    element :name do
+      input(type: :text)
+      output(type: :string)
+    end
+  end
+
+  many :pets, default: [{}] do
+    subform do
+      element :name do
+        input(type: :text)
+        output(type: :string)
+      end
+    end
+  end
+end
+
+RSpec.describe "Form params" do
+  it "renders a form with params" do
+    secure = true
+    child_form = Class.new(RegistrationForm)
+    child_form.params do
+      validates :password, presence: true, if: -> { secure }
+      validates :password_confirmation, presence: true, if: -> { secure }
+      validates :password, confirmation: true, if: -> { secure }
+      profile_attributes_schema do
+        validates :name, presence: true, if: -> { secure }
+      end
+      pets_attributes_schema do
+        validates :name, presence: true, if: -> { secure }
+      end
+    end
+    params = child_form.params_definition.new(profile_attributes: { name: "John Doe" }, email: "john.doe@example.com", password: "password", password_confirmation: "password2")
+    expect(params).to be_invalid
+    expect(params.profile_attributes.name).to eq("John Doe")
+    expect(params.email).to eq("john.doe@example.com")
+    expect(params.password).to eq("password")
+    expect(params.password_confirmation).to eq("password2")
+    expect(params.errors.full_messages).to eq(["Pets attributes[0] name can't be blank", "Password confirmation doesn't match Password"])
+  end
+end


### PR DESCRIPTION
Introduces a `params` method to `ActionForm` for defining parameters using a block, enhancing the flexibility of form parameter definition. This allows for custom validation logic and schema modifications within the form definition. Also includes a new spec file to test this functionality.