### PR TITLE
Allows modification of nested element definitions

### DIFF
--- a/lib/action_form/subform.rb
+++ b/lib/action_form/subform.rb
@@ -11,6 +11,13 @@ module ActionForm
 
     class << self
       attr_accessor :default
+      attr_writer :elements
+
+      def inherited(subclass)
+        super
+        subclass.elements = elements.dup
+        subclass.default = default.dup
+      end
     end
 
     attr_reader :elements_instances, :tags, :name, :object

--- a/lib/action_form/subforms_collection.rb
+++ b/lib/action_form/subforms_collection.rb
@@ -12,12 +12,18 @@ module ActionForm
     attr_accessor :helpers
 
     class << self
-      attr_reader :subform_definition
-      attr_accessor :default, :host_class
+      attr_accessor :default, :host_class, :subform_definition
 
       def subform(subform_class = nil, &block)
-        @subform_definition = subform_class || Class.new(host_class.subform_class)
+        @subform_definition ||= subform_class || Class.new(host_class.subform_class)
         @subform_definition.class_eval(&block) if block
+      end
+
+      def inherited(subclass)
+        super
+        subclass.subform_definition = subform_definition
+        subclass.default = default
+        subclass.host_class = host_class
       end
     end
 

--- a/spec/elements_modifications_spec.rb
+++ b/spec/elements_modifications_spec.rb
@@ -1,0 +1,71 @@
+class OrderForm < ActionForm::Base
+  element :name do
+    input(type: :text)
+    output(type: :string)
+  end
+
+  subform :customer do
+    element :name do
+      input(type: :text)
+      output(type: :string)
+    end
+  end
+
+  many :items do
+    subform do
+      element :name do
+        input(type: :text)
+        output(type: :string)
+      end
+
+      element :quantity do
+        input(type: :number)
+        output(type: :integer)
+      end
+
+      element :price do
+        input(type: :number)
+        output(type: :float)
+      end
+    end
+  end
+end
+
+RSpec.describe "OrderForm" do
+  it "renders a form with params" do
+    secure = true
+    OrderForm.name_element do
+      output(type: :string, presence: true, if: -> { secure })
+    end
+    OrderForm.customer_subform default: {} do
+      name_element do
+        output(type: :string, presence: true, if: -> { secure })
+      end
+    end
+    OrderForm.items_subforms default: [{}] do
+      subform do
+        name_element do
+          output(type: :string, presence: true, if: -> { secure })
+        end
+        quantity_element do
+          output(type: :integer, presence: true, if: -> { secure })
+        end
+        price_element do
+          output(type: :float, presence: true, if: -> { secure })
+        end
+      end
+    end
+    params = OrderForm.params_definition.new()
+
+    expect(params).to be_invalid
+    expect(params.errors.full_messages).to eq(
+      [ "Customer attributes name can't be blank",
+        "Items attributes[0] name can't be blank",
+        "Items attributes[0] quantity can't be blank",
+        "Items attributes[0] price can't be blank",
+        "Name can't be blank"] )
+    expect(params.customer_attributes.errors.full_messages).to eq(["Name can't be blank"])
+    expect(params.items_attributes.first.errors.full_messages).to eq(
+      ["Name can't be blank", "Quantity can't be blank", "Price can't be blank"])
+  end
+end


### PR DESCRIPTION
Enables modification of existing element, subform, and many definitions within ActionForm classes.

This change introduces singleton methods for each element, subform, and many definition, allowing to redefine or extend their behavior.

Adds inheritance of element definitions to ensure that modifications are applied correctly in subclasses.

This addresses the need to customize and extend existing form definitions without altering the original class structure.